### PR TITLE
Issues#5

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -32,8 +32,7 @@ class Admin::UsersController < ApplicationController
   end
 
   def show
-    # binding.pry
-    # @user = User.find(user_params[:id])
+
   end
 
   def index

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -18,7 +18,7 @@
           <td><%= user.id %></td>
           <td><%= user.name %></td>
           <td><%= user.admin %></td>
-          <td><%= user.tasks.count %></td>
+          <td><%= user.tasks.count %></td> 
           <td><%= link_to 'Show', admin_user_path(user) %></td>
           <td><%= link_to 'Edit', edit_admin_user_path(user) %></td>
           <td><%= link_to 'Delete', admin_user_path(user), method: :delete, data: { confirm: 'Are you sure?' } %></td>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -9,9 +9,6 @@
       <th>期限</th>
       <th>ステータス</th>
       <th>優先度</th>
-      <th>閲覧</th>
-      <th>編集</th>
-      <th>削除</th>
       <th colspan="3"></th>
     </tr>
   </thead>
@@ -24,9 +21,6 @@
         <td><%= task.deadline %></td>
         <td><%= task.status_i18n %></td>
         <td><%= task.priority_i18n %></td>
-        <td><%= link_to 'Show', task %></td>
-        <td><%= link_to 'Edit', edit_task_path(task) %></td>
-        <td><%= link_to 'Deliete', task, method: :delete, data: { confirm: 'Are you sure?' } %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -9,6 +9,7 @@
       <th>期限</th>
       <th>ステータス</th>
       <th>優先度</th>
+      <th>タグ</th>
       <th colspan="3"></th>
     </tr>
   </thead>
@@ -21,6 +22,11 @@
         <td><%= task.deadline %></td>
         <td><%= task.status_i18n %></td>
         <td><%= task.priority_i18n %></td>
+        <td>
+          <% task.labels.each do |label| %>
+            <%= label.name %>
+          <% end %>
+        </td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -42,7 +42,7 @@
         <td><%= task.priority_i18n %></td>
         <td>
           <% task.labels.each do |label| %>
-            <%= label.name %><br>
+            <%= label.name %>
           <% end %>
         </td>
         <td><%= link_to 'Show', task %></td>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -35,7 +35,7 @@ ActiveRecord::Schema.define(version: 2020_10_09_024657) do
     t.text "detail", default: "", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.date "deadline"
+    t.date "deadline", null: false
     t.integer "status"
     t.integer "priority"
     t.bigint "user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -35,7 +35,7 @@ ActiveRecord::Schema.define(version: 2020_10_09_024657) do
     t.text "detail", default: "", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.date "deadline", null: false
+    t.date "deadline"
     t.integer "status"
     t.integer "priority"
     t.bigint "user_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,30 +6,28 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-# 15.times do |n|
-#   name = Faker::Games::Pokemon.name
-#   email = Faker::Internet.email
-#   password = "password"
-#   User.create!(name: name,
-#              email: email,
-#              password: password,
-#              password_confirmation: password,
-#               )
-# end
+15.times do |n|
+  name = Faker::Games::Pokemon.name
+  email = Faker::Internet.email
+  password = "password"
+  User.create!(name: name,
+             email: email,
+             password: password,
+             password_confirmation: password,
+              )
+end
 
-# User.create!(name:  "管理者",
-#   email: "admin@example.jp",
-#   password:  "11111111",
-#   password_confirmation: "11111111",
-#   admin: true)
+User.create!(name:  "管理者",
+  email: "admin@example.jp",
+  password:  "11111111",
+  password_confirmation: "11111111",
+  admin: true)
 
 20.times do |n|
   name = Faker::Games::Pokemon.name
   detail = Faker::Games::Pokemon.location
   deadline = Faker::Date.between(from: Date.tomorrow, to: 7.days.since)
   status = ["0","1","2"]
-  binding.pry
-  user_id = ["1","2","3","4","5","6","7","8","9","10","11","12","13","14","15","16"]
   user_id = rand(1..16)
   Task.create!(name: name, detail: detail, deadline: deadline, status: rand(0..2), priority: rand(0..2), user_id: user_id)
 end
@@ -47,7 +45,7 @@ Label.create!(
   name: 'テスト'
 )
 
-binding.pry
+
 20.times do |n|
     Labeling.create!(task_id: rand(1..20), label_id: rand(1..3))
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,11 +1,3 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
-
 15.times do |n|
   name = Faker::Games::Pokemon.name
   email = Faker::Internet.email
@@ -51,16 +43,3 @@ Label.create!(
 end
 
 
-# 20.times do |n|
-#   label = ["開発", "設計", "テスト"]
-#   Label.create!(name: label0, name:label1, name:label2)
-    
-# end
-
-# Label.create!(name: '開発', name: '開発', name: '設計')
-
-
-
-# ["開発", "設計", "テスト"].each do |label|
-#   puts label
-# end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,42 +6,34 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-15.times do |n|
-  name = Faker::Games::Pokemon.name
-  email = Faker::Internet.email
-  password = "password"
-  User.create!(name: name,
-             email: email,
-             password: password,
-             password_confirmation: password,
-              )
-end
+# 15.times do |n|
+#   name = Faker::Games::Pokemon.name
+#   email = Faker::Internet.email
+#   password = "password"
+#   User.create!(name: name,
+#              email: email,
+#              password: password,
+#              password_confirmation: password,
+#               )
+# end
 
-User.create!(name:  "管理者",
-  email: "admin@example.jp",
-  password:  "11111111",
-  password_confirmation: "11111111",
-  admin: true)
+# User.create!(name:  "管理者",
+#   email: "admin@example.jp",
+#   password:  "11111111",
+#   password_confirmation: "11111111",
+#   admin: true)
 
 20.times do |n|
-  # binding.irb
   name = Faker::Games::Pokemon.name
   detail = Faker::Games::Pokemon.location
   deadline = Faker::Date.between(from: Date.tomorrow, to: 7.days.since)
   status = ["0","1","2"]
+  binding.pry
+  user_id = ["1","2","3","4","5","6","7","8","9","10","11","12","13","14","15","16"]
   user_id = rand(1..16)
   Task.create!(name: name, detail: detail, deadline: deadline, status: rand(0..2), priority: rand(0..2), user_id: user_id)
 end
 
-
-# 20.times do |n|
-#   label = ["開発", "設計", "テスト"]
-#   Label.create!(name: label)
-# end
-
-# ["開発", "設計", "テスト"].each do |label|
-#   puts label
-# end
 
 Label.create!(
   name: '開発'
@@ -55,8 +47,22 @@ Label.create!(
   name: 'テスト'
 )
 
+binding.pry
 20.times do |n|
-    Labeling.create!(task_id: rand(1..20), label_id: rand(1..16))
+    Labeling.create!(task_id: rand(1..20), label_id: rand(1..3))
 end
 
 
+# 20.times do |n|
+#   label = ["開発", "設計", "テスト"]
+#   Label.create!(name: label0, name:label1, name:label2)
+    
+# end
+
+# Label.create!(name: '開発', name: '開発', name: '設計')
+
+
+
+# ["開発", "設計", "テスト"].each do |label|
+#   puts label
+# end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -37,7 +37,6 @@ Label.create!(
   name: 'テスト'
 )
 
-
 20.times do |n|
     Labeling.create!(task_id: rand(1..20), label_id: rand(1..3))
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -24,6 +24,7 @@ User.create!(name:  "管理者",
   admin: true)
 
 20.times do |n|
+  # binding.irb
   name = Faker::Games::Pokemon.name
   detail = Faker::Games::Pokemon.location
   deadline = Faker::Date.between(from: Date.tomorrow, to: 7.days.since)
@@ -33,10 +34,26 @@ User.create!(name:  "管理者",
 end
 
 
-20.times do |n|
-  label = ["開発", "設計", "テスト"]
-  Label.create!(name: label)
-end
+# 20.times do |n|
+#   label = ["開発", "設計", "テスト"]
+#   Label.create!(name: label)
+# end
+
+# ["開発", "設計", "テスト"].each do |label|
+#   puts label
+# end
+
+Label.create!(
+  name: '開発'
+)
+
+Label.create!(
+  name: '設計'
+)
+
+Label.create!(
+  name: 'テスト'
+)
 
 20.times do |n|
     Labeling.create!(task_id: rand(1..20), label_id: rand(1..16))


### PR DESCRIPTION
修正しました。
Herokuで一部エラーが出ていたのは
管理者ログイン→User一覧画面→Current_user以外のここでは管理者以外のuserをクリックした際にUser詳細へ飛びますがそこのタスクの詳細と編集と削除が出ておりました。詳細はcurrent_userしか見せないようにcontrollerで制御をしていました。
いくら管理者でも利用ユーザ一覧とユーザの削除や編集はできてもいいけどタスクまでは詳細と編集と削除は不要と思い実装から外しました。（ユーザ削除をすればそれに紐づくタスクは消せます）ただ詳細がなくなりましたがそのユーザがタスクに付けたラベル自体は確認ができます。それと
ログインユーザがタスクを確認するのはNavBarのTaskLisitて記載の横にあるタスク一覧から確認ができます。
（UIは要改善かもですが。。。）

ラベルは１件のタスクに付き複数つけられのも確認しております。
pull requestを作成します。どうぞ宜しくお願い致します。

